### PR TITLE
add ignore flag to ignore specific packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ go-acc $(glide novendor)
 
 Flags:
       --covermode string   Which code coverage mode to use (default "atomic")
+      --ignore strings     Will ignore packages that contains any of these strings
   -o, --output string      Location for the output file (default "coverage.txt")
   -t, --toggle             Help message for toggle
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,8 @@ $ go-acc . -- -short -v -failfast
 			fmt.Println("Flag -v has been deprecated, use `go acc -- -v` instead!")
 		}
 
+		ignores := flagx.MustGetStringSlice(cmd, "ignore")
+
 		payload := "mode: " + mode + "\n"
 
 		var packages []string
@@ -68,7 +70,18 @@ $ go-acc . -- -short -v -failfast
 					//   go: downloading ...
 					//   go: extracting ...
 					if len(s) > 0 && !strings.HasPrefix(s, "go: ") {
-						add = append(add, s)
+						// Test if package name contains ignore string
+						ignore := false
+						for _, ignoreStr := range ignores {
+							if strings.Contains(s, ignoreStr) {
+								ignore = true
+								break
+							}
+						}
+
+						if !ignore {
+							add = append(add, s)
+						}
 					}
 				}
 
@@ -170,6 +183,7 @@ func init() {
 	RootCmd.Flags().BoolP("verbose", "v", false, "Does nothing, there for compatibility")
 	RootCmd.Flags().StringP("output", "o", "coverage.txt", "Location for the output file")
 	RootCmd.Flags().String("covermode", "atomic", "Which code coverage mode to use")
+	RootCmd.Flags().StringSlice("ignore", []string{}, "Will ignore packages that contains any of these strings")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ory/go-acc
+module github.com/schlund/go-acc
 
 require (
 	github.com/ory/x v0.0.85


### PR DESCRIPTION
example usage:

`# ignore every package containing "mock" i.e. github.com/ory/go-acc/mock
go-acc ./... --ignore mock

# connect ignore rules
go-acc ./... --ignore mock,donttestthispackage
go-acc ./... --ignore mock --ignore donttestthispackage`