### PR TITLE
chore: add configure file for goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.exe
 cover.out
 vendor/
+/dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
goreleaser works without any config file, however windows builds are missing.
Here is the build log:

```
shogoichinose@C02CR9E1ML85 go-acc % goreleaser release --rm-dist --snapshot --skip-publish 
   • releasing...     
   • could not find a config file, using defaults...
   • loading environment variables
   • getting and validating git state
      • releasing v0.2.6, commit 65df6aba56a7fcadbe5fa68a2b2529171778b0ab
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag      
   • running before hooks
   • setting defaults 
      • snapshotting     
      • github/gitlab/gitea releases
      • project name     
      • loading go mod information
      • building binaries
      • creating source archive
      • archives         
      • linux packages   
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • docker images    
      • docker manifests 
      • artifactory      
      • blobs            
      • homebrew tap formula
      • scoop manifests  
      • twitter          
      • milestones       
   • snapshotting     
   • checking ./dist  
      • --rm-dist is set, cleaning it up
   • loading go mod information
   • writing effective config file
      • writing                   config=dist/config.yaml
   • generating changelog
      • pipe skipped              error=not available for snapshots
   • building binaries
      • building                  binary=/Users/shogoichinose/src/github.com/shogo82148/go-acc/dist/go-acc_darwin_arm64/go-acc
      • building                  binary=/Users/shogoichinose/src/github.com/shogo82148/go-acc/dist/go-acc_linux_arm64/go-acc
      • building                  binary=/Users/shogoichinose/src/github.com/shogo82148/go-acc/dist/go-acc_linux_386/go-acc
      • building                  binary=/Users/shogoichinose/src/github.com/shogo82148/go-acc/dist/go-acc_darwin_amd64/go-acc
      • building                  binary=/Users/shogoichinose/src/github.com/shogo82148/go-acc/dist/go-acc_linux_amd64/go-acc
   • archives         
      • creating                  archive=dist/go-acc_v0.2.6-SNAPSHOT-65df6ab_darwin_amd64.tar.gz
      • creating                  archive=dist/go-acc_v0.2.6-SNAPSHOT-65df6ab_linux_arm64.tar.gz
      • creating                  archive=dist/go-acc_v0.2.6-SNAPSHOT-65df6ab_darwin_arm64.tar.gz
      • creating                  archive=dist/go-acc_v0.2.6-SNAPSHOT-65df6ab_linux_386.tar.gz
      • creating                  archive=dist/go-acc_v0.2.6-SNAPSHOT-65df6ab_linux_amd64.tar.gz
   • creating source archive
   • linux packages   
   • snapcraft packages
   • calculating checksums
      • checksumming              file=go-acc_v0.2.6-SNAPSHOT-65df6ab_darwin_amd64.tar.gz
      • checksumming              file=go-acc_v0.2.6-SNAPSHOT-65df6ab_linux_arm64.tar.gz
      • checksumming              file=go-acc_v0.2.6-SNAPSHOT-65df6ab_darwin_arm64.tar.gz
      • checksumming              file=go-acc_v0.2.6-SNAPSHOT-65df6ab_linux_386.tar.gz
      • checksumming              file=go-acc_v0.2.6-SNAPSHOT-65df6ab_linux_amd64.tar.gz
   • signing artifacts
   • docker images    
   • publishing       
      • blobs            
      • http upload      
      • custom publisher 
      • artifactory      
      • docker images    
         • pipe skipped              error=publishing is disabled
      • docker manifests 
         • pipe skipped              error=publishing is disabled
      • snapcraft packages
         • pipe skipped              error=publishing is disabled
      • github/gitlab/gitea releases
         • pipe skipped              error=publishing is disabled
      • homebrew tap formula
      • scoop manifests  
         • pipe skipped              error=publishing is disabled
      • milestones       
         • pipe skipped              error=publishing is disabled
   • announcing       
      • twitter          
         • pipe skipped              error=announcing is disabled
   • release succeeded after 2.82s
```

I added windows to the build matrix.
